### PR TITLE
add download support for AssemblyReport

### DIFF
--- a/plugins/configs/KBaseAssembly.AssemblyReport_to_AssemblyOutputFiles.json
+++ b/plugins/configs/KBaseAssembly.AssemblyReport_to_AssemblyOutputFiles.json
@@ -1,0 +1,34 @@
+{
+    "script_name": "trns_transform_KBaseAssembly.AssemblyReport_to_AssemblyOutputFiles.pl",
+    "script_type": "download",
+    "external_type": "AssemblyOutputFiles",
+    "kbase_type": "KBaseAssembly.AssemblyReport",
+    "user_description": "Converts KBaseAssembly.AssemblyReport to assembly output files.",
+    "developer_description": "",
+    "handler_options": {
+        "max_runtime": 600,
+        "required_fields": [
+            "workspace_service_url",
+            "workspace_name",
+            "object_name",
+            "working_directory"
+        ],
+        "optional_fields": ["object_version"],
+        "custom_options": []
+    },
+    "user_options": [
+        {
+            "name": "object_name",
+            "type": "string",
+            "required": true,
+            "help": "Name of the workspace object."
+        },
+        {
+            "name": "object_version",
+            "type": "int",
+            "required": false,
+            "help": "Version of the workspace object, if not given we assume the latest."
+        }
+    ],
+    "user_option_groups": []
+}

--- a/plugins/configs/SequenceReads_to_KBaseAssembly.PairedEndLibrary.json
+++ b/plugins/configs/SequenceReads_to_KBaseAssembly.PairedEndLibrary.json
@@ -1,11 +1,11 @@
 {
     "script_name": "trns_transform_seqs_to_KBaseAssembly_type.pl",
     "script_type": "upload",
-    "external_type": "FASTQ.DNA.Reads",
+    "external_type": "SequenceReads",
     "kbase_type": "KBaseAssembly.PairedEndLibrary",
-    "user_description": "Converts one or two paired FASTQ read files into a KBaseAssembly.PairedEndLibrary typed object.",
-    "developer_description": "Converts one or two paired FASTQ read files into a KBaseAssembly.PairedEndLibrary typed object.",
-    "url_mapping": ["FASTQ.DNA.Reads"],
+    "user_description": "Converts one or two paired sequence read files into a KBaseAssembly.PairedEndLibrary typed object.",
+    "developer_description": "Converts one or two paired sequence read files into a KBaseAssembly.PairedEndLibrary typed object.",
+    "url_mapping": ["SequenceReads"],
     "handler_options":
     {
         "max_runtime": 3600,
@@ -35,7 +35,7 @@
                 "required": true
             }
 	],
-	"input_mapping": [{"input_directory": "FASTQ.DNA.Reads"}]
+	"input_mapping": [{"input_directory": "SequenceReads"}]
     },
     "user_options":
     [

--- a/plugins/configs/SequenceReads_to_KBaseAssembly.SingleEndLibrary.json
+++ b/plugins/configs/SequenceReads_to_KBaseAssembly.SingleEndLibrary.json
@@ -1,0 +1,39 @@
+{
+    "script_name": "trns_transform_seqs_to_KBaseAssembly_type.pl",
+    "script_type": "upload",
+    "external_type": "SequenceReads",
+    "kbase_type": "KBaseAssembly.SingleEndLibrary",
+    "user_description": "Converts a single end FASTQ read file into a KBaseAssembly.SingleEndLibrary typed object.",
+    "developer_description": "Converts a single end FASTQ read file into a KBaseAssembly.SingleEndLibrary typed object.",
+    "url_mapping": ["SequenceReads"],
+    "handler_options":
+    {
+        "max_runtime": 3600,
+        "must_own_validation": false,
+        "must_own_saving_to_workspace": false,
+        "required_fields":
+        [
+            "shock_service_url",
+            "handle_service_url",
+	    "input_directory",
+	    "type",
+	    "file"
+        ],
+        "optional_fields":
+        [
+            "output_file_name",
+            "input_mapping"
+        ],
+        "custom_options": [
+            {
+                "name": "type",
+		"value": "SingleEndLibrary",
+                "type": "string",
+                "required": true
+            }
+	],
+	"input_mapping": [{"input_directory": "SequenceReads"}]
+    },
+    "user_options": [],
+    "user_option_groups": []
+}

--- a/plugins/scripts/download/trns_transform_KBaseAssembly.AssemblyReport_to_AssemblyOutputFiles.pl
+++ b/plugins/scripts/download/trns_transform_KBaseAssembly.AssemblyReport_to_AssemblyOutputFiles.pl
@@ -1,0 +1,97 @@
+#! /usr/bin/env perl
+
+use strict;
+use Data::Dumper;
+use JSON::XS;
+use Getopt::Long::Descriptive;
+use Bio::KBase::workspace::Client;
+use Bio::KBase::GenomeAnnotation::Client;
+use Bio::KBase::Transform::ScriptHelpers qw(get_input_fh get_output_fh load_input write_output write_text_output genome_to_gto);
+
+my($opt, $usage) = describe_options("%c %o",
+				    ['workspace_service_url=s', 'Workspace URL', { default => 'https://kbase.us/services/ws/' }],
+				    ['workspace_name=s', 'Workspace name', { required => 1 }],
+				    ['object_name=s', 'Object name', { required => 1 }],
+				    ['working_directory=s', 'Output directory for generated files', { required => 1 }],
+				    ['object_version', 'Workspace object version'],
+                                    ['token', 'KBase token', { default => $ENV{KB_AUTH_TOKEN}}],
+				    ['help|h', 'show this help message'],
+				   );
+
+print($usage->text), exit  if $opt->help;
+print($usage->text), exit 1 unless @ARGV == 0;
+
+-d $opt->working_directory or die "Specified working directory " . $opt->working_directory . " does not exist\n";
+
+my $wsclient = Bio::KBase::workspace::Client->new($opt->workspace_service_url);
+my $ret = $wsclient->get_objects([{ workspace => $opt->workspace_name,
+                                    name => $opt->object_name,
+                                    (defined($opt->object_version) ? (ver => $opt->object_version) : ()) }]);
+
+ref($ret) eq 'ARRAY' && @$ret && $ret->[0]->{data}
+    or die sprintf("Workspace did not return an object for %s in %s at %s\n", $opt->object_name, $opt->workspace_name, $opt->workspace_service_url);
+
+my $obj = $ret->[0];
+my $type = type_of_object($obj);
+my $data = $obj->{data};
+
+print_output($data->{report}, $opt->working_directory .'/report.txt');
+
+sub print_output {
+    my ($text, $file) = @_;
+    open(F, ">$file") or die "Could not open $file";
+    print F $text;
+    close(F);
+}
+
+sub download_handles_in_data {
+    my ($p) = @_;
+    download_handle($p) if is_handle($p);
+    if (ref($p) eq 'HASH') {
+        download_handles_in_data($_) for values %$p;
+    } elsif (ref($p) eq 'ARRAY') {
+        download_handles_in_data($_) for @$p;
+    }
+}
+
+sub download_handle {
+    my ($handle) = @_;
+    my $token = $opt->token;
+    my $filename = get_handle_filename($handle, $token);
+    my $outfile = $opt->working_directory .'/'. $filename;
+    my $url = $handle->{url} . "/node/" . $handle->{id};
+    my @auth_header;
+    @auth_header = ("-H", "Authorization: OAuth $token") if $token;
+    my @cmd = ("curl", "-s", @auth_header, '-o', $outfile, '-X', 'GET', "$url/?download");
+    my $rc = system(@cmd);
+    die "Failed to run: @cmd\n$!" if $rc != 0;
+}
+
+sub is_handle {
+    my ($p) = @_;
+    return 0 if ref($p) ne 'HASH';
+    return 1 if $p->{type} eq 'shock' && $p->{id} && $p->{url};
+}
+
+sub type_of_object {
+    my ($obj) = @_;
+    my $fulltype = $obj->{info}->[2];
+    my ($type) = $fulltype;
+    $type =~ s/-[0-9.]*$//;
+    return $type;
+}
+
+sub get_handle_filename {
+    my ($handle, $token) = @_;
+
+    my $url = $handle->{url} . "/node/" . $handle->{id};
+    my $auth_header;
+    $auth_header = "-H 'Authorization: OAuth $token'" if $token;
+    my $cmd = "curl -s $auth_header -X GET $url";
+
+    my $json = `$cmd 2> /dev/null`;
+    die "Failed to run: $cmd\n$!" if $? == -1;
+
+    my $ref = decode_json($json);
+    return $ref->{data}->{file}->{name};
+}


### PR DESCRIPTION
also supports uploading generic read files: 

FASTQ / FASTQ / compressed files

	add download support for AssemblyReport

The following configuration files are preferred over FASTQ.DNA.Reads/FASTA.DNA.Reads types:

* SequenceReads_to_KBaseAssembly.PairedEndLibrary.json
* SequenceReads_to_KBaseAssembly.SingleEndLibrary.json