### PR TITLE
Fix to handle shock URLs that are not production

### DIFF
--- a/lib/biokbase/Transform/script_utils.py
+++ b/lib/biokbase/Transform/script_utils.py
@@ -452,6 +452,7 @@ def download_from_urls(logger = None,
             # check for a shock url
             try:
                 shock_id = re.search('^http[s]://.*/node/([a-fA-f0-9\-]+).*', url).group(1)
+                shock_download_url = re.search('^(http[s]://.*)/node/[a-fA-f0-9\-]+.*', url).group(1)
             except Exception, e:
                 shock_id = None
 
@@ -459,13 +460,13 @@ def download_from_urls(logger = None,
                 download_url = url
                 fileName = url.split('/')[-1]
             else:
-                metadata_response = requests.get("{0}/node/{1}?verbosity=metadata".format(shock_service_url, shock_id), headers=header, stream=True, verify=ssl_verify)
+                metadata_response = requests.get("{0}/node/{1}?verbosity=metadata".format(shock_download_url, shock_id), headers=header, stream=True, verify=ssl_verify)
                 shock_metadata = metadata_response.json()['data']
                 fileName = shock_metadata['file']['name']
                 fileSize = shock_metadata['file']['size']
                 metadata_response.close()
                     
-                download_url = "{0}/node/{1}?download_raw".format(shock_service_url, shock_id)
+                download_url = "{0}/node/{1}?download_raw".format(shock_download_url, shock_id)
 
             data = None
             size = 0


### PR DESCRIPTION
The download URL may be something like https://ci.kbase.us/services/shock-api/node/.... instead of //kbase.us.... .  Parse out the Shock node base URL in the download url and use for retrieving the node metadata and contents.