### PR TITLE
Allow for case when to Arg descriptions have the same ending

### DIFF
--- a/lib/biokbase/Transform/script_utils.py
+++ b/lib/biokbase/Transform/script_utils.py
@@ -136,7 +136,7 @@ def parse_docs(docstring=None):
     remainder = script_details["Args"]
     argument_values = list()
     for k in reversed(argument_keys):
-        remainder, value = remainder.split(k)        
+        remainder, _, value = remainder.rpartition(k)        
         argument_values.append(" ".join([x.strip() for x in value.split("\n")]))
     
     # create the dict using they keys without :, then get the values in the correct order


### PR DESCRIPTION
I ran into this because in this description there are two Args that end in "name":

```
    Args:
        shock_service_url: A url for the KBase SHOCK service.
        handle_service_url: A url for the KBase Handle Service.
        output_file_name: A file name where the output JSON string should be
                          stored.
                          If the output file name is not specified the name
                          will default
                          to the name of the input file appended with
                           '_finfo'.
        input_directory: The directory where files will be read from.
        working_directory: The directory the resulting json file will be
                           written to.
        shock_id: Shock id for the hdf file if it already exists in shock
        handle_id: Handle id for the hdf file if it already exists as a
                    handle
        input_mapping: JSON string mapping of input files to expected types.
                       If you don't get this you need to scan the input
                       directory and look for your files.
        level: Logging level, defaults to logging.INFO.
        atlases: List of MetaboliteAtlas atlas IDs.
        name: Name of the file, optional.  Defaults to the file name.
        polarity: Run polarity.
        group: Run group.
        inclusion_order: Run inclusion_order.
        retention_correction: Run retention_correction.
        normalization_factor: Run normalization factor.
```