### PR TITLE
Fixing bug in phenotype import and parsing of TSV/CSV files with windows line endings

### DIFF
--- a/lib/Bio/KBase/Transform/ScriptHelpers.pm
+++ b/lib/Bio/KBase/Transform/ScriptHelpers.pm
@@ -36,7 +36,7 @@ sub parse_input_table {
 	}
 	open(my $fh, "<", $filename) || return;
 	my $headingline = <$fh>;
-	chomp($headingline);
+	$headingline =~ tr/\r\n//d;#This line removes line endings from nix and windows files
 	my $delim = undef;
 	if ($headingline =~ m/\t/) {
 		$delim = "\\t";
@@ -49,7 +49,7 @@ sub parse_input_table {
 	my $headings = [split(/$delim/,$headingline)];
 	my $data = [];
 	while (my $line = <$fh>) {
-		chomp($line);
+		$line =~ tr/\r\n//d;#This line removes line endings from nix and windows files
 		push(@{$data},[split(/$delim/,$line)]);
 	}
 	close($fh);

--- a/plugins/scripts/upload/trns_transform_TSV_Phenotypes_to_KBasePhenotypes_PhenotypeSet.pl
+++ b/plugins/scripts/upload/trns_transform_TSV_Phenotypes_to_KBasePhenotypes_PhenotypeSet.pl
@@ -67,19 +67,20 @@ if($Help || !$In_File || !$Out_Object || !$Out_WS){
 $logger->info("Mandatory Data passed = ".join(" | ", ($In_File,$Out_Object,$Out_WS)));
 $logger->info("Optional Data passed = ".join(" | ", ("Genome:".$Genome)));
 
+#Parsing table from TSV or CSV file based on specs inserted for table columns
 my $phenodata = parse_input_table($In_File,[
-	["geneko",0,[],";"],
+	["geneko",0,"",";"],
 	["media",1,""],
 	["mediaws",1,""],
-	["addtlCpd",0,[],";"],
+	["addtlCpd",0,"",";"],
 	["growth",1]
 ]);
 
 for (my $i=0; $i < @{$phenodata}; $i++) {
-	if ($phenodata->[$i]->[0]->[0] eq "none") {
+	if (defined($phenodata->[$i]->[0]->[0]) && $phenodata->[$i]->[0]->[0] eq "none") {
 		$phenodata->[$i]->[0] = [];
 	}
-	if ($phenodata->[$i]->[3]->[0] eq "none") {
+	if (defined($phenodata->[$i]->[3]->[0]) && $phenodata->[$i]->[3]->[0] eq "none") {
 		$phenodata->[$i]->[3] = [];
 	}
 }


### PR DESCRIPTION
This fixes parsing of files with windows line endings for all the perl importers that use the "parse_input_table" function. While testing, I also found a bug with default values specified for columns in the phenotype transform script, so this was fixed as well.

Fix was tested with Collin's phenotype file that contains windows line endings, and it worked perfectly.