### PR TITLE
Fix for failure in "make deploy"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ include $(TOP_DIR)/tools/Makefile.common.rules
 
 # here are the standard KBase deployment targets (deploy,deploy-client, deploy-scripts, & deploy-service)
 
-deploy: deploy-libs deploy-scripts deploy-service deploy-r-scripts deploy-bins deploy-jars
+deploy: deploy-libs deploy-scripts deploy-service deploy-bins deploy-jars
 
 deploy-bins:
 	rsync --exclude '*.bak*' -arv bin/. $(TARGET)/bin/.


### PR DESCRIPTION
I have this error when I run "make deploy":
make: *** No rule to make target `deploy-r-scripts', needed by `deploy'.  Stop.