### PR TITLE
propagating status and error messages back to the client on upload

### DIFF
--- a/plugins/scripts/taskrunners/trns_upload_taskrunner.py
+++ b/plugins/scripts/taskrunners/trns_upload_taskrunner.py
@@ -263,10 +263,12 @@ def upload_taskrunner(ujs_service_url = None, workspace_service_url = None,
                         logger.info("UJS message : " + "Attempting to validate {0}".format(filename)[:handler_utils.UJS_STATUS_MAX])
                         ujs.update_job_progress(ujs_job_id, kb_token, "Attempting to validate {0}".format(filename)[:handler_utils.UJS_STATUS_MAX], 
                                                 1, est.strftime('%Y-%m-%dT%H:%M:%S+0000'))
+
+                        task_output = handler_utils.run_task(logger, validation_args, callback=lambda msg: \
+                            ujs.update_job_progress(ujs_job_id, kb_token, msg.split("-")[-1][:handler_utils.UJS_STATUS_MAX], 1, est.strftime('%Y-%m-%dT%H:%M:%S+0000')))
                     else:
                         logger.info("Attempting to validate {0}".format(filename))
-
-                    task_output = handler_utils.run_task(logger, validation_args)
+                        task_output = handler_utils.run_task(logger, validation_args)
                 
                     if task_output["stdout"] is not None:
                         logger.debug("STDOUT : " + str(task_output["stdout"]))
@@ -407,7 +409,11 @@ def upload_taskrunner(ujs_service_url = None, workspace_service_url = None,
             logger.debug(transformation_args)
             os.mkdir(transform_directory)            
 
-            task_output = handler_utils.run_task(logger, transformation_args, debug=debug)
+            if ujs_job_id is not None:
+                task_output = handler_utils.run_task(logger, transformation_args, debug=debug, callback=lambda msg: \
+                    ujs.update_job_progress(ujs_job_id, kb_token, msg.split("-")[-1][:handler_utils.UJS_STATUS_MAX], 1, est.strftime('%Y-%m-%dT%H:%M:%S+0000')))
+            else:
+                task_output = handler_utils.run_task(logger, transformation_args, debug=debug)
         
             if task_output["stdout"] is not None:
                 logger.debug("STDOUT : " + str(task_output["stdout"]))

--- a/t/demo/conf/upload_ci.cfg
+++ b/t/demo/conf/upload_ci.cfg
@@ -1,11 +1,11 @@
 {
     "services": {
-        "shock": "https://ci.kbase.us/services/shock-api/",
-        "ujs": "https://ci.kbase.us/services/userandjobstate/",
-        "workspace": "https://ci.kbase.us/services/ws/",
-        "handle": "https://ci.kbase.us/services/handle_service/",
-        "transform": "https://ci.kbase.us/services/transform/",
-        "awe": "https://ci.kbase.us/services/awe_api/"
+        "shock_service_url": "https://ci.kbase.us/services/shock-api/",
+        "ujs_service_url": "https://ci.kbase.us/services/userandjobstate/",
+        "workspace_service_url": "https://ci.kbase.us/services/ws/",
+        "handle_service_url": "https://ci.kbase.us/services/handle_service/",
+        "transform_service_url": "https://ci.kbase.us/services/transform/",
+        "awe_service_url": "https://ci.kbase.us/services/awe_api/"
     },
     "upload": {
         "fasta_to_contigset": {


### PR DESCRIPTION
A callback function was added to the handler_utils.run_task() method in order to support custom behavior per line of output from stdout/stderr of a running task.  The default if not set by the taskrunner is to log the messages local to the task.  The upload taskrunner is set here to send every line as a UJS status message, where the line is trimmed to conform to the UJS limit of 200 characters.

When an exception is thrown, the method in handler_utils that catches the error now checks first to see if the job has already been completed before attempting to end the job.  This will prevent an unnecessary exception about the job not existing after an error, and hopefully make the error messages easier to follow.

The CI config file used for manual testing (potentially useful for automated testing) was updated with correct key names for the client test tools.