### PR TITLE
pass back stderr or stdout on task exception

### DIFF
--- a/lib/biokbase/Transform/handler_utils.py
+++ b/lib/biokbase/Transform/handler_utils.py
@@ -150,7 +150,7 @@ class TaskRunner(object):
     
         self.logger.info("Executing {0}".format(" ".join(command_list)))
     
-        task = subprocess.Popen(command_list, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        task = subprocess.Popen(command_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         
         lines_iterator = iter(task.stdout.readline, b"")
         for line in lines_iterator:
@@ -163,7 +163,7 @@ class TaskRunner(object):
         task_output["stderr"] = sub_stderr
         
         if task.returncode != 0:
-            raise Exception(task_output)
+            raise Exception(task_output["stdout"], task_output["stderr"])
         else:
             return task_output
 

--- a/t/demo/conf/upload_ci.cfg
+++ b/t/demo/conf/upload_ci.cfg
@@ -5,7 +5,7 @@
         "workspace_service_url": "https://ci.kbase.us/services/ws/",
         "handle_service_url": "https://ci.kbase.us/services/handle_service/",
         "transform_service_url": "https://ci.kbase.us/services/transform/",
-        "awe_service_url": "https://ci.kbase.us/services/awe_api/"
+        "awe_service_url": "https://ci.kbase.us/services/awe-api/"
     },
     "upload": {
         "fasta_to_contigset": {


### PR DESCRIPTION
Maintain separate stdout and stderr streams, only live print stdout.  On error, throw an exception with both stdout and stderr as arguments.  If one is None and the other is not, return that in the final UJS details, and if both are None send back a stack trace.

Additional correction in client testing config for awe url in CI changing from awe_api to awe-api.