### PR TITLE
Update upload_script_test with default flag

### DIFF
--- a/t/demo/bin/upload_script_test.py
+++ b/t/demo/bin/upload_script_test.py
@@ -396,7 +396,7 @@ if __name__ == "__main__":
                 if type(input_object[x]) == type(dict()):
                     input_object[x] = base64.urlsafe_b64encode(simplejson.dumps(input_object[x]))
 
-            command_list = ["trns_upload_taskrunner", "--ujs_job_id", ujs_job_id]
+            command_list = ["trns_upload_taskrunner", "--ujs_job_id", ujs_job_id, "--keep_working_directory"]
             
             for k in input_object:
                command_list.append("--{0}".format(k))


### PR DESCRIPTION
Use keep_working_directory by default to keep the output of the run for inspection.
The default behavior of the upload_taskrunner is to clean up at the end, but here you want to see the results and then manually clean up.