### PR TITLE
Raise an exception if a FTP URL cannot be expanded. 

### DIFF
--- a/lib/biokbase/Transform/script_utils.py
+++ b/lib/biokbase/Transform/script_utils.py
@@ -501,6 +501,8 @@ def download_from_urls(logger = stderrlogger(__file__),
                 file_list = ftp_connection.listdir(path)
             elif ftp_connection.path.isfile(path):
                 file_list = [path]
+            else:
+                raise Exception('File not found for FTP URL "{0}"'.format(url))
 
             if len(file_list) > 1:            
                 if len(file_list) > threshold:


### PR DESCRIPTION
Replaces this crash with an exception:

Error:
Traceback (most recent call last):
  File "/kb/deployment/pybin/trns_upload_taskrunner.py", line 151, in upload_taskrunner
    token=kb_token)
  File "/kb/deployment/lib/biokbase/Transform/script_utils.py", line 505, in download_from_urls
    if len(file_list) > 1:
UnboundLocalError: local variable 'file_list' referenced before assignment