### PR TITLE
Develop

### DIFF
--- a/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomes_Genome.py
+++ b/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomes_Genome.py
@@ -78,11 +78,17 @@ def transform(shock_service_url=None, workspace_service_url=None,
     if stdout is not None and len(stdout) > 0:
         logger.info(stdout)
 
-    if stderr is not None and len(stderr) > 0:
+    exit_status = tool_process.wait()
+
+    if exit_status != 0:
         logger.error("Transformation from Genbank.Genome to KBaseGenomes.Genome failed on {0}".format(input_directory))
-        logger.error(stderr)
+	if stderr is not None:
+	    logger.error(stderr)
         sys.exit(1)
     
+    if stderr is not None and len(stderr) > 0:
+        logger.warning("Transformation from Genbank.Genome to KBaseGenomes.Genome on {0} issued diagnostics:".format(input_directory))
+        logger.warning(stderr)
     
     logger.info("Transformation from Genbank.Genome to KBaseGenomes.Genome completed.")
     sys.exit(0)

--- a/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomes_Genome.py
+++ b/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomes_Genome.py
@@ -79,6 +79,7 @@ def transform(shock_service_url=None, workspace_service_url=None,
         logger.info(stdout)
 
     exit_status = tool_process.wait()
+    logger.debug("Tool execution returned exit status {}".format(exit_status))
 
     if exit_status != 0:
         logger.error("Transformation from Genbank.Genome to KBaseGenomes.Genome failed on {0}".format(input_directory))

--- a/src/us/kbase/genbank/ConvertGBK.java
+++ b/src/us/kbase/genbank/ConvertGBK.java
@@ -685,6 +685,7 @@ public class ConvertGBK {
                 ConvertGBK clt = new ConvertGBK(args);
             } catch (Exception e) {
                 e.printStackTrace();
+		System.exit(1);
             }
         } else {
             System.out.println("usage: java us.kbase.genbank.ConvertGBK " +


### PR DESCRIPTION
The genbank parser issues diagnostic messages to stderr; their presence does not signal a failed transform. Standard practice is to catch a non-zero return code as the indicator of a failed transformation.

The python change here cause the transform to succeed as long as it gets a zero return from the parser. 

The java change causes the parser to issue a nonzero exit code when it catches an exception during parse.

@realmarcin this touches your code as well.