### PR TITLE
Fixed error in generating IDs for data series

### DIFF
--- a/src/us/kbase/kbaseenigmametals/DataMatrixUploader.java
+++ b/src/us/kbase/kbaseenigmametals/DataMatrixUploader.java
@@ -474,8 +474,8 @@ public class DataMatrixUploader {
 				seriesIndex++;
 				entry.getValue().add(
 						new PropertyValue()
-						.withCategory("DataSeries")
-						.withPropertyName("SeriesId")
+						.withCategory(MetadataProperties.DATAMATRIX_METADATA_COLUMN_DATASERIES)
+						.withPropertyName(MetadataProperties.DATAMATRIX_METADATA_COLUMN_DATASERIES_SERIESID)
 						.withPropertyUnit("")
 						.withPropertyValue("S" + seriesIndex)); 
 			}


### PR DESCRIPTION
This error prevented upload of GrowthMatrix objects without user-defined data series IDs