### PR TITLE
Remove Popen.wait() call

### DIFF
--- a/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomes_Genome.py
+++ b/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomes_Genome.py
@@ -78,7 +78,7 @@ def transform(shock_service_url=None, workspace_service_url=None,
     if stdout is not None and len(stdout) > 0:
         logger.info(stdout)
 
-    exit_status = tool_process.wait()
+    exit_status = tool_process.returncode
     logger.debug("Tool execution returned exit status {}".format(exit_status))
 
     if exit_status != 0:


### PR DESCRIPTION
Using Popen.wait() is incorrect usage here.  I should have reviewed this change more carefully.

Popen.communicate() already waits for the process to terminate, documented here:
https://docs.python.org/2/library/subprocess.html#subprocess.Popen.communicate

In addition, the usage of Popen.wait() when using PIPE can lead to deadlocks, with the recommendation to use Popen.communicate() which was already present, documented here:
https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

The correct call would be to retrieve the already set returncode value after Popen.communicate() has returned.
https://docs.python.org/2/library/subprocess.html#subprocess.Popen.returncode

This is actually a bugfix that needs to propagate anywhere this code was deployed to avoid hanging processes on upload.