### PR TITLE
Removing hardcoded path in Genbank validator

### DIFF
--- a/plugins/scripts/validate/trns_validate_Genbank_Genome.py
+++ b/plugins/scripts/validate/trns_validate_Genbank_Genome.py
@@ -36,7 +36,7 @@ def transform(input_file=None,
     
     token = os.environ.get("KB_AUTH_TOKEN")
 
-    classpath = "/kb/dev_container/modules/transform/lib/jars/kbase/transform/kbase_transform_deps:$KB_TOP/lib/jars/kbase/genomes/kbase-genomes-20140411.jar:$KB_TOP/lib/jars/kbase/common/kbase-common-0.0.6.jar:$KB_TOP/lib/jars/jackson/jackson-annotations-2.2.3.jar:$KB_TOP/lib/jars/jackson/jackson-core-2.2.3.jar:$KB_TOP/lib/jars/jackson/jackson-databind-2.2.3.jar:$KB_TOP/lib/jars/kbase/transform/kbase_transform_deps.jar:$KB_TOP/lib/jars/kbase/auth/kbase-auth-1398468950-3552bb2.jar:$KB_TOP/lib/jars/kbase/workspace/WorkspaceClient-0.2.0.jar"
+    classpath = "$KB_TOP/lib/jars/kbase/genomes/kbase-genomes-20140411.jar:$KB_TOP/lib/jars/kbase/common/kbase-common-0.0.6.jar:$KB_TOP/lib/jars/jackson/jackson-annotations-2.2.3.jar:$KB_TOP/lib/jars/jackson/jackson-core-2.2.3.jar:$KB_TOP/lib/jars/jackson/jackson-databind-2.2.3.jar:$KB_TOP/lib/jars/kbase/transform/kbase_transform_deps.jar:$KB_TOP/lib/jars/kbase/auth/kbase-auth-1398468950-3552bb2.jar:$KB_TOP/lib/jars/kbase/workspace/WorkspaceClient-0.2.0.jar"
     mc = 'us.kbase.genbank.ValidateGBK'
 
     java_classpath = os.path.join(os.environ.get("KB_TOP"), classpath.replace('$KB_TOP', os.environ.get("KB_TOP")))


### PR DESCRIPTION
This validator is currently disabled, but I found a hardcoded path that should be removed.
This just is further evidence that I need to review PRs more carefully to not let these kinds of things into the codebase.