### PR TITLE
Convert to old Genome objects

### DIFF
--- a/lib/git_install.sh
+++ b/lib/git_install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+GIT=git
+GITHUB_URL='https://github.com'
+
+mkdir clonetemp
+
+for dep in  'kbase/user_and_job_state' 'kbase/workspace_deluxe' \
+           'mlhenderson/handle_service' 'kbase/kbapi_common'
+do
+    url="$GITHUB_URL/$dep"
+    cmd="$GIT clone $url"
+    printf "RUN: %s\n" "$cmd"
+    cd clonetemp
+    $cmd
+    depdir=`basename $dep`
+    libdir="$depdir/lib/biokbase"
+    rm -f $libdir/__init__.py
+    printf "Copying $libdir/* into biokbase\n"
+    cp -r $libdir/* ../biokbase/
+    cd ..
+done
+
+# library needed for filemagic
+brew install libmagic

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -9,3 +9,4 @@ blessings
 python-dateutil
 simplejson
 bzr
+biopython

--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,0 +1,11 @@
+pip
+ftputil
+requests
+httplib2
+requests_toolbelt
+gitpython
+filemagic
+blessings
+python-dateutil
+simplejson
+bzr

--- a/plugins/configs/FASTA.DNA.Assembly_to_KBaseGenomeAnnotations.Assembly.json
+++ b/plugins/configs/FASTA.DNA.Assembly_to_KBaseGenomeAnnotations.Assembly.json
@@ -26,7 +26,8 @@
             "shock_id", 
             "handle_id",
             "input_mapping",
-            "source"
+            "source",
+            "no_convert"
         ],
         "custom_options": [],
 	"input_mapping": {"FASTA.DNA.Assembly":"input_directory"}

--- a/plugins/configs/Genbank.Genome_to_KBaseGenomeAnnotations.GenomeAnnotation.json
+++ b/plugins/configs/Genbank.Genome_to_KBaseGenomeAnnotations.GenomeAnnotation.json
@@ -20,8 +20,9 @@
         ], 
         "optional_fields": 
         [
-	    "object_name",
-            "source"
+	        "object_name",
+            "source",
+            "no_convert"
         ],
         
         "input_mapping":{"Genbank.Genome":"input_directory"},

--- a/plugins/scripts/upload/trns_transform_FASTA_DNA_Assembly_to_KBaseGenomeAnnotations_Assembly.py
+++ b/plugins/scripts/upload/trns_transform_FASTA_DNA_Assembly_to_KBaseGenomeAnnotations_Assembly.py
@@ -20,6 +20,7 @@ import simplejson
 import biokbase.Transform.script_utils as script_utils
 import biokbase.Transform.TextFileDecoder as TextFileDecoder
 import biokbase.workspace.client 
+from doekbase.data_api.converters import genome as cvt
 
 # transformation method that can be called if this module is imported
 # Note the logger has different levels it could be run.  
@@ -356,6 +357,7 @@ def upload_assembly(shock_service_url = None,
     
     logger.info("Conversion completed.")
 
+    return assembly_name
 
 # called only if script is run from command line
 if __name__ == "__main__":
@@ -386,7 +388,10 @@ if __name__ == "__main__":
     parser.add_argument('--input_directory', 
                         help="Directory the fasta file is in", 
                         action='store', type=str, nargs='?', required=True)
-#    parser.add_argument('--shock_id', 
+    parser.add_argument('--no_convert', action='store_true', dest='no_convert_to_old_type',
+                        help='After upload, do NOT add equivalent ContigSet object, '
+                             'in the same workspace (for backwards compatibility)')
+#    parser.add_argument('--shock_id',
 #                        help=script_details["Args"]["shock_id"],
 #                        action='store', type=str, nargs='?', default=None, required=False)
 #    parser.add_argument('--handle_id', 
@@ -403,8 +408,8 @@ if __name__ == "__main__":
 
     logger.debug(args)
     try:
-    
-        upload_assembly(shock_service_url = args.shock_service_url, 
+
+        obj_name = upload_assembly(shock_service_url = args.shock_service_url,
                         handle_service_url = args.handle_service_url, 
                         input_directory = args.input_directory, 
 #                  shock_id = args.shock_id, 
@@ -419,7 +424,22 @@ if __name__ == "__main__":
     except Exception, e:
         logger.exception(e)
         sys.exit(1)
-    
+
+    if args.no_convert_to_old_type:
+        logger.info('Conversion to legacy types skipped by request')
+    else:
+        logger.info('Converting to legacy type, object={}'.format(obj_name))
+        try:
+            cvt.convert_assembly(shock_url=args.shock_service_url,
+                                 handle_url=args.handle_service_url,
+                                 ws_url=args.workspace_service_url,
+                                 obj_name=obj_name,
+                                 ws_name=args.workspace_name)
+        except cvt.ConvertOldTypeException as e:
+            logger.exception(e)
+            sys.exit(2)
+
+
     sys.exit(0)
 
 

--- a/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomeAnnotations_GenomeAnnotation.py
+++ b/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomeAnnotations_GenomeAnnotation.py
@@ -28,7 +28,7 @@ import biokbase.Transform.script_utils as script_utils
 import biokbase.Transform.TextFileDecoder as TextFileDecoder
 import biokbase.workspace.client 
 import trns_transform_FASTA_DNA_Assembly_to_KBaseGenomeAnnotations_Assembly as assembly
-
+from doekbase.data_api.converters import base, genome
 
 
 def make_scientific_names_lookup(taxon_names_file=None):
@@ -1794,7 +1794,43 @@ def upload_genome(shock_service_url=None,
 #            raise 
 
     logger.info("Conversions completed.")
+    return genome_annotation_object_name
 
+class ConversionError(Exception):
+    pass
+
+def convert_genome(shock_url=None, handle_url=None, ws_url=None, obj_name=None, ws_name=None):
+    """Convert uploaded GenomeAnnotation to a Genome + ContigSet object.
+
+    Args:
+        shock_url:
+        handle_url:
+        ws_url:
+        obj_name:
+        ws_name:
+
+    Returns:
+        (str) Object reference of Genome object
+    Raises:
+        ConversionError, if conversion fails
+    """
+
+    # add custom set of service URLs
+    base.Converter.all_services['upload'] = dict(
+        workspace_service_url=ws_url, shock_service_url=shock_url,
+        handle_service_url=handle_url)
+
+    # create source reference from upload workspace and object names
+    source_ref = '{}/{}'.format(ws_name, obj_name)
+
+    # perform the conversion
+    try:
+        converter = genome.GenomeConverter(kbase_instance='upload', ref=source_ref)
+        target_ref = converter.convert(ws_name)
+    except Exception as e:
+        raise ConversionError(e)
+
+    return target_ref
 
 # called only if script is run from command line
 if __name__ == "__main__":
@@ -1843,7 +1879,10 @@ if __name__ == "__main__":
     parser.add_argument('--input_directory', 
                         help="directory the genbank file is in", 
                         action='store', type=str, nargs='?', required=True)
-#    parser.add_argument('--output_file_name', 
+    parser.add_argument('--convert', action='store_true', dest='convert_to_old_type',
+                        help='After upload, convert and add new Genome and ContigSet for '
+                        'backwards-compatibility with methods that use the old object types.')
+#   parser.add_argument('--output_file_name',
 #                        help=script_details["Args"]["output_file_name"],
 #                        action='store', type=str, nargs='?', default=None, required=False)
 #    parser.add_argument('--shock_id', 
@@ -1863,29 +1902,39 @@ if __name__ == "__main__":
 
     logger.debug(args)
     try:
-        upload_genome(shock_service_url = args.shock_service_url, 
-                      handle_service_url = args.handle_service_url, 
-                      #                  output_file_name = args.output_file_name, 
-                      #                      input_file_name = args.input_file_name, 
-                      input_directory = args.input_directory, 
-                      #                  shock_id = args.shock_id, 
-                      #                  handle_id = args.handle_id,
-                      #                  input_mapping = args.input_mapping,
-                      workspace_name = args.workspace_name,
-                      workspace_service_url = args.workspace_service_url,
-                      taxon_wsname = args.taxon_wsname,
-                      exclude_feature_types = args.exclude_feature_types,
-#                      taxon_names_file = args.taxon_names_file,
-                      taxon_reference = args.taxon_reference,
-                      core_genome_name = args.object_name,
-                      source = args.source,
-                      release = args.release,
-                      type = args.type,
-                      #                      genome_list_file = args.genome_list_file,
-                      logger = logger)
+        obj_name = upload_genome(
+            shock_service_url = args.shock_service_url,
+            handle_service_url = args.handle_service_url,
+            #                  output_file_name = args.output_file_name,
+            #                      input_file_name = args.input_file_name,
+            input_directory = args.input_directory,
+            #                  shock_id = args.shock_id,
+            #                  handle_id = args.handle_id,
+            #                  input_mapping = args.input_mapping,
+            workspace_name = args.workspace_name,
+            workspace_service_url = args.workspace_service_url,
+            taxon_wsname = args.taxon_wsname,
+            exclude_feature_types = args.exclude_feature_types,
+            #                      taxon_names_file = args.taxon_names_file,
+            taxon_reference = args.taxon_reference,
+            core_genome_name = args.object_name,
+            source = args.source,
+            release = args.release,
+            type = args.type,
+            #                      genome_list_file = args.genome_list_file,
+            logger = logger)
     except Exception, e:
         logger.exception(e)
         sys.exit(1)
+
+    if args.convert_to_old_type:
+        try:
+            convert_genome(shock_url=args.shock_service_url, handle_url=args.handle_service_url,
+                           ws_url=args.workspace_service_url, obj_name=obj_name,
+                           ws_name=args.workspace_name)
+        except ConversionError as e:
+            logger.exception(e)
+            sys.exit(2)
     
     sys.exit(0)
 

--- a/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomeAnnotations_GenomeAnnotation.py
+++ b/plugins/scripts/upload/trns_transform_Genbank_Genome_to_KBaseGenomeAnnotations_GenomeAnnotation.py
@@ -1899,7 +1899,8 @@ def convert_genome(shock_url=None, handle_url=None, ws_url=None, obj_name=None, 
     Raises:
         ConversionError, if conversion fails
     """
-    log = script_utils.stderrlogger(__file__)
+    log = script_utils.stderrlogger(__file__ + '.convert_genome')
+    log.propagate = False
     # Add custom set of service URLs,
     # since the Converter is invoked with a named group of URLs.
     kb_services = 'upload'
@@ -1911,14 +1912,14 @@ def convert_genome(shock_url=None, handle_url=None, ws_url=None, obj_name=None, 
     source_ref = '{}/{}'.format(ws_name, obj_name)
 
     # perform the conversion
-    log.info('Begin: Convert to old type. ref={}'.format(source_ref))
+    log.info('Begin: Convert source={}'.format(source_ref))
     try:
         converter = genome.GenomeConverter(kbase_instance=kb_services, ref=source_ref)
         target_ref = converter.convert(ws_name)
     except Exception as e:
-        log.error('Failed: Convert to old type. ref={}'.format(source_ref))
+        log.error('Failed: Convert source={}: {}'.format(source_ref, str(e)))
         raise ConvertOldTypeException(e, ws_url=ws_url, source_ref=source_ref)
-    log.info('Success: Convert to old type. ref={}'.format(source_ref))
+    log.info('Success: Convert source={} output={}'.format(source_ref, target_ref))
     return target_ref
 
 #####################################################################


### PR DESCRIPTION
Use Python module doekbase.converters.genome to add an optional step to a Genome Annotation upload that creates from the annotation and assembly objects the old genome and contigset objects (in the same workspace).

Progress:
- [x] Add --no-convert option(s) to transform plugin(s)
  - [x] Genbank upload
  - [x] FASTA upload
- [x] Test with local execution
