### PR TITLE
install data_api as a dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SERVICE_PORT = 7778
 
 BRANCH = $(shell git symbolic-ref HEAD 2>/dev/null)
 
-ifneq ($(filter $(BRANCH),"develop staging master"),)
+ifneq ($(filter $(BRANCH),refs/heads/develop refs/heads/staging refs/heads/master),)
 # if one of the develop/staging/master branches, strip the refs/heads/ portion
 BRANCH := $(subst refs/heads/,,$(BRANCH))
 else

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,16 @@ SERVICE_DIR_NAME = transform
 SERVICE_DIR = $(TARGET)/services/$(SERVICE_NAME)
 SERVICE_PORT = 7778
 
+BRANCH = $(shell git symbolic-ref HEAD 2>/dev/null)
+
+ifneq ($(filter $(BRANCH),"develop staging master"),)
+# if one of the develop/staging/master branches, strip the refs/heads/ portion
+BRANCH := $(subst refs/heads/,,$(BRANCH))
+else
+# else if using an unknown branch of transform, default to master branch of data_api
+BRANCH = master
+endif
+
 DIR = $(shell pwd)
 
 TPAGE = $(DEPLOY_RUNTIME)/bin/tpage
@@ -165,11 +175,8 @@ deploy-jars:
 deploy-client: deploy-libs deploy-scripts deploy-docs deploy-data-api
 
 deploy-data-api:
-        branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
-	git clone https://github.com/kbase/data_api -b $branch
-	cd data_api
-	pip install .
-	cd ..
+	git clone https://github.com/kbase/data_api -b $(BRANCH)
+	cd data_api;pip install .;cd ..
 	rm -rf data_api
 
 # Deploy command line scripts.  The scripts are "wrapped" so users do not

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,15 @@ deploy-jars:
 # Deploy client artifacts, including the application programming interface
 # libraries, command line scripts, and associated reference documentation.
 
-deploy-client: deploy-libs deploy-scripts deploy-docs
+deploy-client: deploy-libs deploy-scripts deploy-docs deploy-data-api
+
+deploy-data-api:
+        branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+	git clone https://github.com/kbase/data_api -b $branch
+	cd data_api
+	pip install .
+	cd ..
+	rm -rf data_api
 
 # Deploy command line scripts.  The scripts are "wrapped" so users do not
 # need to modify their environment to run KBase scripts.


### PR DESCRIPTION
Added Makefile lines to install data_api when deploy-client is run.  This will deploy data_api to the awe workers so that converters can import the module.
