### PR TITLE
set to develop for now as a temp fix, must correct later

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ SERVICE_DIR_NAME = transform
 SERVICE_DIR = $(TARGET)/services/$(SERVICE_NAME)
 SERVICE_PORT = 7778
 
-BRANCH ?= $(shell git symbolic-ref HEAD 2>/dev/null)
-BRANCH := $(subst refs/heads/,,$(BRANCH))
+#BRANCH ?= $(shell git symbolic-ref HEAD 2>/dev/null)
+#BRANCH := $(subst refs/heads/,,$(BRANCH))
+BRANCH = develop
 
 DIR = $(shell pwd)
 


### PR DESCRIPTION
Forcing install of data_api -b develop just for now to have things work in CI, but I have to fix this as soon as I return from vacation.
